### PR TITLE
feat: add configurable global copy shortcut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,12 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+
+      - name: Clear SPM artifact cache
+        run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts/
 
       - name: Build
         run: make build

--- a/ZuluBar/AppDelegate.swift
+++ b/ZuluBar/AppDelegate.swift
@@ -457,11 +457,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         )
     }
 
-    /// Unregisters any existing hot-key then registers the currently saved shortcut.
-    /// Safe to call with no shortcut set (becomes a no-op after unregistering).
-    func registerHotKey() {
-        unregisterHotKey()
-        guard let shortcut = copyShortcut else { return }
+    /// Attempts to register the currently saved shortcut without disturbing the existing one.
+    /// The old registration is only released after the new one succeeds, so a failed
+    /// registration leaves the previous hotkey intact. Returns whether registration succeeded.
+    @discardableResult
+    func registerHotKey() -> Bool {
+        guard let shortcut = copyShortcut else {
+            unregisterHotKey()
+            return true
+        }
 
         var carbonModifiers: UInt32 = 0
         if shortcut.modifierFlags.contains(.command) { carbonModifiers |= UInt32(cmdKey) }
@@ -473,17 +477,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         hotKeyID.signature = 0x5A554C55  // "ZULU"
         hotKeyID.id = 1
 
+        var newRef: EventHotKeyRef?
         let status = RegisterEventHotKey(
             UInt32(shortcut.keyCode),
             carbonModifiers,
             hotKeyID,
             GetApplicationEventTarget(),
             0,
-            &hotKeyRef
+            &newRef
         )
-        if status != noErr {
+
+        guard status == noErr, let newRef = newRef else {
             print("ZuluBar: Failed to register hotkey (error \(status))")
+            return false
         }
+
+        // New registration succeeded — safe to release the previous one
+        unregisterHotKey()
+        hotKeyRef = newRef
+        return true
     }
 
     private func unregisterHotKey() {
@@ -496,8 +508,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         recorderPanel?.close()
         recorderPanel = HotKeyRecorderPanel(current: copyShortcut)
         recorderPanel?.onShortcutChanged = { [weak self] shortcut in
-            self?.copyShortcut = shortcut
-            self?.registerHotKey()
+            guard let self = self else { return }
+            let previous = self.copyShortcut
+            self.copyShortcut = shortcut
+            if !self.registerHotKey() {
+                // Registration failed — roll back to the previous binding
+                self.copyShortcut = previous
+                self.registerHotKey()
+                self.recorderPanel?.registrationFailed()
+            }
         }
         NSApp.activate(ignoringOtherApps: true)
         recorderPanel?.makeKeyAndOrderFront(nil)

--- a/ZuluBar/AppDelegate.swift
+++ b/ZuluBar/AppDelegate.swift
@@ -1,3 +1,4 @@
+import Carbon
 import Cocoa
 import ServiceManagement
 #if IS_PAID_BUILD
@@ -7,11 +8,24 @@ import Sparkle
 /// Main application delegate that manages the status bar item and user interactions
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
+    // MARK: - Types (Hot Key)
+
+    /// A resolved keyboard shortcut binding.
+    struct HotKey {
+        let keyCode: UInt16
+        let modifierFlags: NSEvent.ModifierFlags
+        /// Human-readable display string, e.g. "⌘⇧C".
+        let display: String
+    }
+
     // MARK: - Properties
 
     var statusItem: NSStatusItem!
     var timer: Timer?
     var isShowingFeedback = false
+    private var hotKeyRef: EventHotKeyRef?
+    private var hotKeyHandler: EventHandlerRef?
+    private var recorderPanel: HotKeyRecorderPanel?
     #if IS_PAID_BUILD
     private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     #endif
@@ -31,6 +45,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         static let dateFormat = "dateFormat"
         static let displaySuffix = "displaySuffix"
         static let copyFormat = "copyFormat"
+        static let copyShortcutKeyCode = "copyShortcutKeyCode"
+        static let copyShortcutModifiers = "copyShortcutModifiers"
+        static let copyShortcutDisplay = "copyShortcutDisplay"
     }
 
     // MARK: - Types
@@ -111,6 +128,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         set { UserDefaults.standard.set(newValue.rawValue, forKey: UserDefaultsKeys.copyFormat) }
     }
 
+    var copyShortcut: HotKey? {
+        get {
+            guard let display = UserDefaults.standard.string(forKey: UserDefaultsKeys.copyShortcutDisplay),
+                  !display.isEmpty else { return nil }
+            let keyCode = UInt16(clamping: UserDefaults.standard.integer(forKey: UserDefaultsKeys.copyShortcutKeyCode))
+            let raw = UInt(bitPattern: UserDefaults.standard.integer(forKey: UserDefaultsKeys.copyShortcutModifiers))
+            return HotKey(keyCode: keyCode, modifierFlags: NSEvent.ModifierFlags(rawValue: raw), display: display)
+        }
+        set {
+            if let shortcut = newValue {
+                UserDefaults.standard.set(Int(shortcut.keyCode), forKey: UserDefaultsKeys.copyShortcutKeyCode)
+                UserDefaults.standard.set(Int(bitPattern: UInt(shortcut.modifierFlags.rawValue)), forKey: UserDefaultsKeys.copyShortcutModifiers)
+                UserDefaults.standard.set(shortcut.display, forKey: UserDefaultsKeys.copyShortcutDisplay)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutKeyCode)
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutModifiers)
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutDisplay)
+            }
+        }
+    }
+
     var launchAtLogin: Bool {
         get { SMAppService.mainApp.status == .enabled }
         set {
@@ -139,6 +177,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         #endif
 
         setupStatusItem()
+        installHotKeyHandler()
+        registerHotKey()
         updateUTC()
         startTimer()
     }
@@ -272,6 +312,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         copyFormatItem.submenu = copyFormatSubmenu
         menu.addItem(copyFormatItem)
 
+        // Copy Shortcut
+        let shortcutTitle = copyShortcut.map { "Copy Shortcut (\($0.display))" } ?? "Copy Shortcut…"
+        let copyShortcutItem = NSMenuItem(title: shortcutTitle, action: #selector(openShortcutRecorder), keyEquivalent: "")
+        menu.addItem(copyShortcutItem)
+
         menu.addItem(NSMenuItem.separator())
 
         #if IS_PAID_BUILD
@@ -385,6 +430,78 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case .z: return .z
         case .none: return .none
         }
+    }
+
+    // MARK: - Hot Key Management
+
+    /// Installs the Carbon event handler that fires on every registered hot-key press.
+    /// Call once at launch; the handler stays alive for the app's lifetime.
+    private func installHotKeyHandler() {
+        var eventSpec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        let selfPointer = Unmanaged.passUnretained(self).toOpaque()
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { (_, _, userData) -> OSStatus in
+                guard let ptr = userData else { return OSStatus(eventNotHandledErr) }
+                let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
+                delegate.copyTimeToClipboard()
+                return noErr
+            },
+            1,
+            &eventSpec,
+            selfPointer,
+            &hotKeyHandler
+        )
+    }
+
+    /// Unregisters any existing hot-key then registers the currently saved shortcut.
+    /// Safe to call with no shortcut set (becomes a no-op after unregistering).
+    func registerHotKey() {
+        unregisterHotKey()
+        guard let shortcut = copyShortcut else { return }
+
+        var carbonModifiers: UInt32 = 0
+        if shortcut.modifierFlags.contains(.command) { carbonModifiers |= UInt32(cmdKey) }
+        if shortcut.modifierFlags.contains(.shift)   { carbonModifiers |= UInt32(shiftKey) }
+        if shortcut.modifierFlags.contains(.option)  { carbonModifiers |= UInt32(optionKey) }
+        if shortcut.modifierFlags.contains(.control) { carbonModifiers |= UInt32(controlKey) }
+
+        var hotKeyID = EventHotKeyID()
+        hotKeyID.signature = 0x5A554C55  // "ZULU"
+        hotKeyID.id = 1
+
+        let status = RegisterEventHotKey(
+            UInt32(shortcut.keyCode),
+            carbonModifiers,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &hotKeyRef
+        )
+        if status != noErr {
+            print("ZuluBar: Failed to register hotkey (error \(status))")
+        }
+    }
+
+    private func unregisterHotKey() {
+        guard let ref = hotKeyRef else { return }
+        UnregisterEventHotKey(ref)
+        hotKeyRef = nil
+    }
+
+    @objc private func openShortcutRecorder() {
+        recorderPanel?.close()
+        recorderPanel = HotKeyRecorderPanel(current: copyShortcut)
+        recorderPanel?.onShortcutChanged = { [weak self] shortcut in
+            self?.copyShortcut = shortcut
+            self?.registerHotKey()
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        recorderPanel?.makeKeyAndOrderFront(nil)
+        recorderPanel?.center()
     }
 
     // MARK: - Timer Management

--- a/ZuluBar/HotKeyRecorderPanel.swift
+++ b/ZuluBar/HotKeyRecorderPanel.swift
@@ -25,6 +25,7 @@ class HotKeyRecorderPanel: NSPanel {
     private let doneButton = NSButton()
 
     private var currentShortcut: AppDelegate.HotKey?
+    private var shortcutBeforeAttempt: AppDelegate.HotKey?
     private var isRecording = false
     private var localEventMonitor: Any?
 
@@ -184,9 +185,12 @@ class HotKeyRecorderPanel: NSPanel {
         let shortcut = AppDelegate.HotKey(keyCode: event.keyCode, modifierFlags: modifiers, display: display)
 
         stopRecording(restoreDisplay: false)
+        shortcutBeforeAttempt = currentShortcut
         currentShortcut = shortcut
         updateDisplay(animated: false)
         onShortcutChanged?(shortcut)
+        // If registration failed, registrationFailed() was called synchronously above
+        // and has already restored currentShortcut and updated the display.
     }
 
     @objc private func clearShortcut() {
@@ -194,6 +198,19 @@ class HotKeyRecorderPanel: NSPanel {
         currentShortcut = nil
         updateDisplay(animated: false)
         onShortcutChanged?(nil)
+    }
+
+    /// Called by the owner when a shortcut recorded via `onShortcutChanged` could not be
+    /// registered (e.g. the key combo is claimed by macOS or another app). Rolls the
+    /// display back to the previous binding and shows a brief error message.
+    func registrationFailed() {
+        currentShortcut = shortcutBeforeAttempt
+        shortcutLabel.stringValue = "Already claimed"
+        shortcutLabel.textColor = .systemRed
+        hintLabel.stringValue = "That combo is taken by another app"
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
+            self?.updateDisplay(animated: false)
+        }
     }
 
     @objc private func done() {

--- a/ZuluBar/HotKeyRecorderPanel.swift
+++ b/ZuluBar/HotKeyRecorderPanel.swift
@@ -1,0 +1,266 @@
+import Cocoa
+import Carbon
+
+/// A small floating panel that lets the user record or clear a keyboard shortcut.
+///
+/// Usage:
+/// ```swift
+/// let panel = HotKeyRecorderPanel(current: copyShortcut)
+/// panel.onShortcutChanged = { [weak self] shortcut in ... }
+/// panel.makeKeyAndOrderFront(nil)
+/// ```
+class HotKeyRecorderPanel: NSPanel {
+
+    // MARK: - Public
+
+    /// Called immediately when the user records a new shortcut or clears the existing one.
+    var onShortcutChanged: ((AppDelegate.HotKey?) -> Void)?
+
+    // MARK: - Private
+
+    private let shortcutLabel = NSTextField(labelWithString: "")
+    private let hintLabel = NSTextField(labelWithString: "")
+    private let recordButton = NSButton()
+    private let clearButton = NSButton()
+    private let doneButton = NSButton()
+
+    private var currentShortcut: AppDelegate.HotKey?
+    private var isRecording = false
+    private var localEventMonitor: Any?
+
+    // MARK: - Init
+
+    init(current: AppDelegate.HotKey?) {
+        self.currentShortcut = current
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 150),
+            styleMask: [.titled, .closable, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        title = "Copy Shortcut"
+        isFloatingPanel = true
+        level = .floating
+        isReleasedWhenClosed = false
+        setupUI()
+        updateDisplay(animated: false)
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        guard let contentView = contentView else { return }
+
+        // Shortcut label — large display of the current binding
+        shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
+        shortcutLabel.alignment = .center
+        shortcutLabel.font = .monospacedSystemFont(ofSize: 22, weight: .medium)
+        contentView.addSubview(shortcutLabel)
+
+        // Hint label — secondary instruction text
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintLabel.alignment = .center
+        hintLabel.font = .systemFont(ofSize: 11)
+        hintLabel.textColor = .secondaryLabelColor
+        contentView.addSubview(hintLabel)
+
+        // Record button
+        recordButton.translatesAutoresizingMaskIntoConstraints = false
+        recordButton.bezelStyle = .rounded
+        recordButton.target = self
+        recordButton.action = #selector(toggleRecording)
+        contentView.addSubview(recordButton)
+
+        // Clear button
+        clearButton.translatesAutoresizingMaskIntoConstraints = false
+        clearButton.title = "Clear"
+        clearButton.bezelStyle = .rounded
+        clearButton.target = self
+        clearButton.action = #selector(clearShortcut)
+        contentView.addSubview(clearButton)
+
+        // Done button (default action)
+        doneButton.translatesAutoresizingMaskIntoConstraints = false
+        doneButton.title = "Done"
+        doneButton.bezelStyle = .rounded
+        doneButton.keyEquivalent = "\r"
+        doneButton.target = self
+        doneButton.action = #selector(done)
+        contentView.addSubview(doneButton)
+
+        NSLayoutConstraint.activate([
+            shortcutLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            shortcutLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            shortcutLabel.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 16),
+            shortcutLabel.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -16),
+
+            hintLabel.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            hintLabel.topAnchor.constraint(equalTo: shortcutLabel.bottomAnchor, constant: 4),
+
+            recordButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            recordButton.topAnchor.constraint(equalTo: hintLabel.bottomAnchor, constant: 10),
+            recordButton.widthAnchor.constraint(equalToConstant: 140),
+
+            clearButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            clearButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
+
+            doneButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            doneButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
+        ])
+    }
+
+    // MARK: - Display
+
+    private func updateDisplay(animated: Bool) {
+        if isRecording {
+            shortcutLabel.stringValue = "…"
+            shortcutLabel.textColor = .tertiaryLabelColor
+            hintLabel.stringValue = "Press a key combination  (Esc to cancel)"
+            recordButton.title = "Cancel"
+            clearButton.isEnabled = false
+        } else if let shortcut = currentShortcut {
+            shortcutLabel.stringValue = shortcut.display
+            shortcutLabel.textColor = .labelColor
+            hintLabel.stringValue = "Click Record to change"
+            recordButton.title = "Record"
+            clearButton.isEnabled = true
+        } else {
+            shortcutLabel.stringValue = "—"
+            shortcutLabel.textColor = .tertiaryLabelColor
+            hintLabel.stringValue = "No shortcut set"
+            recordButton.title = "Record"
+            clearButton.isEnabled = false
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func toggleRecording() {
+        if isRecording {
+            stopRecording(restoreDisplay: true)
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        isRecording = true
+        updateDisplay(animated: true)
+
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleCapturedKey(event)
+            return nil  // consume the event
+        }
+    }
+
+    private func stopRecording(restoreDisplay: Bool) {
+        isRecording = false
+        if let monitor = localEventMonitor {
+            NSEvent.removeMonitor(monitor)
+            localEventMonitor = nil
+        }
+        if restoreDisplay {
+            updateDisplay(animated: false)
+        }
+    }
+
+    private func handleCapturedKey(_ event: NSEvent) {
+        // Esc cancels without saving
+        if event.keyCode == UInt16(kVK_Escape) {
+            stopRecording(restoreDisplay: true)
+            return
+        }
+
+        let modifiers = event.modifierFlags.intersection([.command, .option, .control, .shift])
+
+        // Require at least one of ⌘, ⌃, or ⌥ — shift-only shortcuts are not valid
+        guard modifiers.contains(.command) || modifiers.contains(.option) || modifiers.contains(.control) else {
+            shortcutLabel.stringValue = "Add ⌘, ⌃, or ⌥"
+            shortcutLabel.textColor = .systemOrange
+            return
+        }
+
+        let display = buildDisplayString(keyCode: event.keyCode, modifiers: modifiers)
+        let shortcut = AppDelegate.HotKey(keyCode: event.keyCode, modifierFlags: modifiers, display: display)
+
+        stopRecording(restoreDisplay: false)
+        currentShortcut = shortcut
+        updateDisplay(animated: false)
+        onShortcutChanged?(shortcut)
+    }
+
+    @objc private func clearShortcut() {
+        stopRecording(restoreDisplay: false)
+        currentShortcut = nil
+        updateDisplay(animated: false)
+        onShortcutChanged?(nil)
+    }
+
+    @objc private func done() {
+        stopRecording(restoreDisplay: false)
+        orderOut(nil)
+    }
+
+    // MARK: - Panel Lifecycle
+
+    override func close() {
+        stopRecording(restoreDisplay: false)
+        super.close()
+    }
+
+    // MARK: - Key Name Helpers
+
+    private func buildDisplayString(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> String {
+        var result = ""
+        if modifiers.contains(.control) { result += "⌃" }
+        if modifiers.contains(.option)  { result += "⌥" }
+        if modifiers.contains(.shift)   { result += "⇧" }
+        if modifiers.contains(.command) { result += "⌘" }
+        result += keyName(for: keyCode)
+        return result
+    }
+
+    private func keyName(for keyCode: UInt16) -> String {
+        // Named keys that UCKeyTranslate doesn't produce useful strings for
+        let namedKeys: [UInt16: String] = [
+            36: "↩", 48: "⇥", 49: "Space", 51: "⌫", 53: "⎋",
+            96: "F5", 97: "F6", 98: "F7", 99: "F3", 100: "F8",
+            101: "F9", 103: "F11", 105: "F13", 107: "F14", 109: "F10",
+            111: "F12", 113: "F15", 115: "↖", 116: "⇞", 117: "⌦",
+            118: "F4", 119: "↘", 120: "F2", 121: "⇟", 122: "F1",
+            123: "←", 124: "→", 125: "↓", 126: "↑",
+        ]
+        if let name = namedKeys[keyCode] { return name }
+        return characterName(for: keyCode) ?? "(\(keyCode))"
+    }
+
+    /// Translates a virtual key code to its unmodified character using the current keyboard layout.
+    private func characterName(for keyCode: UInt16) -> String? {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else { return nil }
+        guard let layoutDataRef = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else { return nil }
+        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue() as Data
+
+        return layoutData.withUnsafeBytes { rawBuffer -> String? in
+            guard let layoutPtr = rawBuffer.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else { return nil }
+            var deadKeyState: UInt32 = 0
+            var unicodeChars = [UniChar](repeating: 0, count: 4)
+            var charCount = 0
+            let status = UCKeyTranslate(
+                layoutPtr,
+                keyCode,
+                UInt16(kUCKeyActionDisplay),
+                0,
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                4,
+                &charCount,
+                &unicodeChars
+            )
+            guard status == noErr, charCount > 0 else { return nil }
+            let scalars = unicodeChars[0..<charCount].compactMap { Unicode.Scalar(UInt32($0)) }
+            let string = String(String.UnicodeScalarView(scalars)).uppercased()
+            return string.isEmpty ? nil : string
+        }
+    }
+}

--- a/ZuluBarTests/AppDelegateTests.swift
+++ b/ZuluBarTests/AppDelegateTests.swift
@@ -5,7 +5,10 @@ final class AppDelegateTests: XCTestCase {
 
     private var delegate: AppDelegate!
     private let defaults = UserDefaults.standard
-    private let testKeys = ["showSeconds", "showDate", "dateFormat", "displaySuffix", "copyFormat"]
+    private let testKeys = [
+        "showSeconds", "showDate", "dateFormat", "displaySuffix", "copyFormat",
+        "copyShortcutKeyCode", "copyShortcutModifiers", "copyShortcutDisplay",
+    ]
 
     override func setUp() {
         super.setUp()
@@ -71,6 +74,46 @@ final class AppDelegateTests: XCTestCase {
         delegate.dateFormat = .dayDateMonth
         XCTAssertEqual(delegate.dateFormat, .dayDateMonth)
         XCTAssertEqual(defaults.string(forKey: "dateFormat"), "Tue 2 Dec")
+    }
+
+    // MARK: - Copy Shortcut
+
+    func testCopyShortcutDefaultIsNil() {
+        XCTAssertNil(delegate.copyShortcut)
+    }
+
+    func testCopyShortcutPersists() {
+        let shortcut = AppDelegate.HotKey(
+            keyCode: 8,
+            modifierFlags: [.command],
+            display: "⌘C"
+        )
+        delegate.copyShortcut = shortcut
+        XCTAssertEqual(delegate.copyShortcut?.keyCode, 8)
+        XCTAssertEqual(delegate.copyShortcut?.display, "⌘C")
+        XCTAssertTrue(delegate.copyShortcut?.modifierFlags.contains(.command) == true)
+        XCTAssertEqual(defaults.integer(forKey: "copyShortcutKeyCode"), 8)
+        XCTAssertEqual(defaults.string(forKey: "copyShortcutDisplay"), "⌘C")
+    }
+
+    func testCopyShortcutClearRemovesAllKeys() {
+        delegate.copyShortcut = AppDelegate.HotKey(keyCode: 8, modifierFlags: [.command], display: "⌘C")
+        delegate.copyShortcut = nil
+        XCTAssertNil(delegate.copyShortcut)
+        XCTAssertNil(defaults.object(forKey: "copyShortcutKeyCode"))
+        XCTAssertNil(defaults.object(forKey: "copyShortcutModifiers"))
+        XCTAssertNil(defaults.object(forKey: "copyShortcutDisplay"))
+    }
+
+    func testCopyShortcutModifierRoundTrip() {
+        let flags: NSEvent.ModifierFlags = [.command, .shift]
+        delegate.copyShortcut = AppDelegate.HotKey(keyCode: 3, modifierFlags: flags, display: "⌘⇧F")
+        let recovered = delegate.copyShortcut
+        XCTAssertNotNil(recovered)
+        XCTAssertTrue(recovered?.modifierFlags.contains(.command) == true)
+        XCTAssertTrue(recovered?.modifierFlags.contains(.shift) == true)
+        XCTAssertFalse(recovered?.modifierFlags.contains(.option) == true)
+        XCTAssertFalse(recovered?.modifierFlags.contains(.control) == true)
     }
 
     // MARK: - Copy Format Output


### PR DESCRIPTION
Adds a user-configurable global hotkey that triggers copy to clipboard.

- Carbon `RegisterEventHotKey` for system-wide registration; unregisters before re-registering on every change
- Shortcut stored in UserDefaults (keyCode, modifierFlags, display string); defaults to unset
- Small floating recorder panel: Record, Clear, Done; requires ⌘/⌃/⌥ modifier
- Menu item shows active binding when set
- 4 new tests covering persistence and modifier round-trip

Closes #10