### PR TITLE
refactor: extract StatusBarRenderer and dedupe DisplaySuffix

### DIFF
--- a/ZuluBar/AppDelegate.swift
+++ b/ZuluBar/AppDelegate.swift
@@ -29,13 +29,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     #if IS_PAID_BUILD
     private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     #endif
-    private lazy var dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(abbreviation: "UTC")
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.calendar = Calendar(identifier: .gregorian)
-        return formatter
-    }()
 
     // MARK: - UserDefaults Keys
 
@@ -57,26 +50,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         case display = "Display"
         case unixTimestamp = "Unix Timestamp"
         case rfc3339 = "RFC 3339"
-    }
-
-    /// Available suffixes for status bar display
-    enum DisplaySuffix: String, CaseIterable {
-        case utc = "UTC"
-        case z = "Z"
-        case none = "None"
-    }
-
-    /// Available date formats for status bar display
-    enum DateFormat: String, CaseIterable {
-        case dayMonthDate = "Tue Dec 2"
-        case dayDateMonth = "Tue 2 Dec"
-
-        var formatString: String {
-            switch self {
-            case .dayMonthDate: return "E MMM d"      // Tue Dec 2
-            case .dayDateMonth: return "E d MMM"      // Tue 2 Dec
-            }
-        }
     }
 
     // MARK: - Settings
@@ -102,10 +75,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         set { UserDefaults.standard.set(newValue.rawValue, forKey: UserDefaultsKeys.dateFormat) }
     }
 
-    var displaySuffix: DisplaySuffix {
+    var displaySuffix: UTCTimeFormatter.Suffix {
         get {
             if let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.displaySuffix),
-               let suffix = DisplaySuffix(rawValue: rawValue) {
+               let suffix = UTCTimeFormatter.Suffix(rawValue: rawValue) {
                 return suffix
             }
             return .z
@@ -296,7 +269,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let copyFormatItem = NSMenuItem(title: "Copy Format", action: nil, keyEquivalent: "")
         let copyFormatSubmenu = NSMenu()
 
-        let displayExample = UTCTimeFormatter.format(as: .humanReadable(showSeconds: showSeconds, suffix: convertDisplaySuffix(displaySuffix)))
+        let displayExample = UTCTimeFormatter.format(as: .humanReadable(showSeconds: showSeconds, suffix: displaySuffix))
         let displayItem = NSMenuItem(title: "Display (\(displayExample))", action: #selector(setCopyFormatDisplay), keyEquivalent: "")
         displayItem.state = copyFormat == .display ? .on : .off
         copyFormatSubmenu.addItem(displayItem)
@@ -413,7 +386,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         switch copyFormat {
         case .display:
             // Match current display settings for copy output
-            format = .humanReadable(showSeconds: showSeconds, suffix: convertDisplaySuffix(displaySuffix))
+            format = .humanReadable(showSeconds: showSeconds, suffix: displaySuffix)
         case .unixTimestamp:
             format = .unixTimestamp
         case .rfc3339:
@@ -421,15 +394,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
 
         return UTCTimeFormatter.format(as: format)
-    }
-
-    /// Converts DisplaySuffix to UTCTimeFormatter.Suffix
-    private func convertDisplaySuffix(_ suffix: DisplaySuffix) -> UTCTimeFormatter.Suffix {
-        switch suffix {
-        case .utc: return .utc
-        case .z: return .z
-        case .none: return .none
-        }
     }
 
     // MARK: - Hot Key Management
@@ -553,19 +517,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // Don't update if showing feedback
         guard !isShowingFeedback else { return }
 
-        var displayText = ""
-
-        // Add date if enabled
-        if showDate {
-            dateFormatter.dateFormat = dateFormat.formatString
-            displayText = dateFormatter.string(from: Date()) + " "
-        }
-
-        // Add time
-        let suffix = convertDisplaySuffix(displaySuffix)
-        let format = UTCTimeFormatter.Format.humanReadable(showSeconds: showSeconds, suffix: suffix)
-        displayText += UTCTimeFormatter.format(as: format)
-
-        statusItem.button?.title = displayText
+        let display = StatusBarDisplay(
+            dateFormat: showDate ? dateFormat : nil,
+            timeFormat: .humanReadable(showSeconds: showSeconds, suffix: displaySuffix)
+        )
+        statusItem.button?.title = StatusBarRenderer.render(display)
     }
 }

--- a/ZuluBar/StatusBarRenderer.swift
+++ b/ZuluBar/StatusBarRenderer.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Formats for the date prefix displayed before the time in the status bar.
+enum DateFormat: String, CaseIterable {
+    case dayMonthDate = "Tue Dec 2"
+    case dayDateMonth = "Tue 2 Dec"
+
+    var formatString: String {
+        switch self {
+        case .dayMonthDate: return "E MMM d"
+        case .dayDateMonth: return "E d MMM"
+        }
+    }
+}
+
+/// Describes what should be rendered into the status bar title.
+struct StatusBarDisplay {
+    /// Optional date prefix. When `nil`, no date is shown.
+    let dateFormat: DateFormat?
+    let timeFormat: UTCTimeFormatter.Format
+}
+
+/// Renders a `StatusBarDisplay` into the final status bar title string.
+/// Composes `UTCTimeFormatter` for the time half and owns the `DateFormatter`
+/// for the date prefix, so callers stay out of formatting details.
+enum StatusBarRenderer {
+
+    // Cached DateFormatters — configured once, always UTC/POSIX/Gregorian.
+    // DateFormatter is not thread-safe; these are only used from the main thread.
+    private static let dayMonthDateFormatter = makeDateFormatter(dateFormat: DateFormat.dayMonthDate.formatString)
+    private static let dayDateMonthFormatter = makeDateFormatter(dateFormat: DateFormat.dayDateMonth.formatString)
+
+    private static func makeDateFormatter(dateFormat: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = dateFormat
+        return formatter
+    }
+
+    private static func dateFormatter(for format: DateFormat) -> DateFormatter {
+        switch format {
+        case .dayMonthDate: return dayMonthDateFormatter
+        case .dayDateMonth: return dayDateMonthFormatter
+        }
+    }
+
+    static func render(_ display: StatusBarDisplay, at date: Date = Date()) -> String {
+        var result = ""
+        if let dateFormat = display.dateFormat {
+            result = dateFormatter(for: dateFormat).string(from: date) + " "
+        }
+        result += UTCTimeFormatter.format(date, as: display.timeFormat)
+        return result
+    }
+}

--- a/ZuluBar/TimeFormatter.swift
+++ b/ZuluBar/TimeFormatter.swift
@@ -12,13 +12,15 @@ struct UTCTimeFormatter {
         case rfc3339
     }
 
-    /// Available suffixes for human-readable format
-    enum Suffix {
-        case utc
-        case z
-        case none
+    /// Available suffixes for human-readable format.
+    /// `rawValue` is the persisted identifier; `displayString` is what gets
+    /// appended to the formatted time.
+    enum Suffix: String, CaseIterable {
+        case utc = "UTC"
+        case z = "Z"
+        case none = "None"
 
-        var stringValue: String {
+        var displayString: String {
             switch self {
             case .utc: return " UTC"
             case .z: return "Z"
@@ -59,7 +61,7 @@ struct UTCTimeFormatter {
         switch format {
         case .humanReadable(let showSeconds, let suffix):
             let formatter = showSeconds ? humanReadableFormatterSeconds : humanReadableFormatterNoSeconds
-            return formatter.string(from: date) + suffix.stringValue
+            return formatter.string(from: date) + suffix.displayString
 
         case .unixTimestamp:
             return String(Int(date.timeIntervalSince1970))


### PR DESCRIPTION
## Summary

Two small, independent cleanups bundled together as the first step of a staged AppDelegate refactor.

**A. Extract `StatusBarRenderer`.** AppDelegate owned a lazy `DateFormatter` used only to prepend a date to the status bar title. That formatter now lives next to `UTCTimeFormatter` in a new `StatusBarRenderer.swift`, driven by a small `StatusBarDisplay` value type. `updateUTC()` collapses from 14 lines to 7, and display composition has a single home.

**B. Dedupe `DisplaySuffix` into `UTCTimeFormatter.Suffix`.** `AppDelegate.DisplaySuffix` and `UTCTimeFormatter.Suffix` were the same enum with a bridge function (`convertDisplaySuffix(_:)`) between them. `Suffix` now conforms to `RawRepresentable` with rawValues matching the previously persisted strings (`"UTC"`/`"Z"`/`"None"`), so no migration is needed. Bridge function deleted. `Suffix.stringValue` renamed to `displayString` to avoid colliding with the new `rawValue` meaning.

`DateFormat` moves to `StatusBarRenderer.swift` since it only affects rendering.

## Test plan

- [x] `make build-free` succeeds
- [x] `make test` — all 25 tests pass
- [x] Manual: run free build, verify status bar shows time with each suffix option (Z / UTC / None)
- [x] Manual: enable date prefix in both formats (`Tue Dec 2` and `Tue 2 Dec`)
- [x] Manual: persisted `displaySuffix` from prior install still loads (rawValues preserved)