### PR TITLE
refactor: extract Settings, HotKey, and HotKeyManager

### DIFF
--- a/ZuluBar/AppDelegate.swift
+++ b/ZuluBar/AppDelegate.swift
@@ -1,126 +1,25 @@
-import Carbon
 import Cocoa
 import ServiceManagement
 #if IS_PAID_BUILD
 import Sparkle
 #endif
 
-/// Main application delegate that manages the status bar item and user interactions
+/// Main application delegate that manages the status bar item and user interactions.
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
-
-    // MARK: - Types (Hot Key)
-
-    /// A resolved keyboard shortcut binding.
-    struct HotKey {
-        let keyCode: UInt16
-        let modifierFlags: NSEvent.ModifierFlags
-        /// Human-readable display string, e.g. "⌘⇧C".
-        let display: String
-    }
 
     // MARK: - Properties
 
     var statusItem: NSStatusItem!
     var timer: Timer?
     var isShowingFeedback = false
-    private var hotKeyRef: EventHotKeyRef?
-    private var hotKeyHandler: EventHandlerRef?
+    var settings = Settings()
+    private let hotKeyManager = HotKeyManager()
     private var recorderPanel: HotKeyRecorderPanel?
     #if IS_PAID_BUILD
     private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     #endif
 
-    // MARK: - UserDefaults Keys
-
-    private enum UserDefaultsKeys {
-        static let showSeconds = "showSeconds"
-        static let showDate = "showDate"
-        static let dateFormat = "dateFormat"
-        static let displaySuffix = "displaySuffix"
-        static let copyFormat = "copyFormat"
-        static let copyShortcutKeyCode = "copyShortcutKeyCode"
-        static let copyShortcutModifiers = "copyShortcutModifiers"
-        static let copyShortcutDisplay = "copyShortcutDisplay"
-    }
-
-    // MARK: - Types
-
-    /// Available formats for copying time to clipboard
-    enum CopyFormat: String, CaseIterable {
-        case display = "Display"
-        case unixTimestamp = "Unix Timestamp"
-        case rfc3339 = "RFC 3339"
-    }
-
-    // MARK: - Settings
-
-    var showSeconds: Bool {
-        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.showSeconds) as? Bool ?? true }
-        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.showSeconds) }
-    }
-
-    var showDate: Bool {
-        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.showDate) as? Bool ?? false }
-        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.showDate) }
-    }
-
-    var dateFormat: DateFormat {
-        get {
-            if let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.dateFormat),
-               let format = DateFormat(rawValue: rawValue) {
-                return format
-            }
-            return .dayMonthDate
-        }
-        set { UserDefaults.standard.set(newValue.rawValue, forKey: UserDefaultsKeys.dateFormat) }
-    }
-
-    var displaySuffix: UTCTimeFormatter.Suffix {
-        get {
-            if let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.displaySuffix),
-               let suffix = UTCTimeFormatter.Suffix(rawValue: rawValue) {
-                return suffix
-            }
-            return .z
-        }
-        set { UserDefaults.standard.set(newValue.rawValue, forKey: UserDefaultsKeys.displaySuffix) }
-    }
-
-    var copyFormat: CopyFormat {
-        get {
-            if let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.copyFormat) {
-                if rawValue == "Human Readable" {
-                    return .display
-                }
-                if let format = CopyFormat(rawValue: rawValue) {
-                    return format
-                }
-            }
-            return .display
-        }
-        set { UserDefaults.standard.set(newValue.rawValue, forKey: UserDefaultsKeys.copyFormat) }
-    }
-
-    var copyShortcut: HotKey? {
-        get {
-            guard let display = UserDefaults.standard.string(forKey: UserDefaultsKeys.copyShortcutDisplay),
-                  !display.isEmpty else { return nil }
-            let keyCode = UInt16(clamping: UserDefaults.standard.integer(forKey: UserDefaultsKeys.copyShortcutKeyCode))
-            let raw = UInt(bitPattern: UserDefaults.standard.integer(forKey: UserDefaultsKeys.copyShortcutModifiers))
-            return HotKey(keyCode: keyCode, modifierFlags: NSEvent.ModifierFlags(rawValue: raw), display: display)
-        }
-        set {
-            if let shortcut = newValue {
-                UserDefaults.standard.set(Int(shortcut.keyCode), forKey: UserDefaultsKeys.copyShortcutKeyCode)
-                UserDefaults.standard.set(Int(bitPattern: UInt(shortcut.modifierFlags.rawValue)), forKey: UserDefaultsKeys.copyShortcutModifiers)
-                UserDefaults.standard.set(shortcut.display, forKey: UserDefaultsKeys.copyShortcutDisplay)
-            } else {
-                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutKeyCode)
-                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutModifiers)
-                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.copyShortcutDisplay)
-            }
-        }
-    }
+    // MARK: - Launch at Login
 
     var launchAtLogin: Bool {
         get { SMAppService.mainApp.status == .enabled }
@@ -150,15 +49,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         #endif
 
         setupStatusItem()
-        installHotKeyHandler()
-        registerHotKey()
+        hotKeyManager.onTrigger = { [weak self] in self?.copyTimeToClipboard() }
+        hotKeyManager.activate(settings.copyShortcut)
         updateUTC()
         startTimer()
     }
 
     // MARK: - Setup
 
-    /// Configures the status bar item with appropriate styling and click handlers
+    /// Configures the status bar item with appropriate styling and click handlers.
     private func setupStatusItem() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
@@ -169,9 +68,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // MARK: - User Interaction
 
-    /// Handles clicks on the status bar item
-    /// - Left click: Copies current time to clipboard
-    /// - Right click: Shows options menu
+    /// Handles clicks on the status bar item.
+    /// - Left click: copies current time to clipboard.
+    /// - Right click: shows options menu.
     @objc func statusItemClicked() {
         guard let event = NSApp.currentEvent else { return }
 
@@ -182,7 +81,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 
-    /// Shows the options menu below the status bar item
+    /// Shows the options menu below the status bar item.
     private func showOptionsMenu() {
         let menu = setupMenu()
         menu.delegate = self
@@ -193,7 +92,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
     }
 
-    /// Copies the current time to clipboard and shows visual feedback
+    /// Copies the current time to clipboard and shows visual feedback.
     private func copyTimeToClipboard() {
         let textToCopy = getFormattedTimeForCopy()
         let pasteboard = NSPasteboard.general
@@ -203,7 +102,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         showCopiedFeedback()
     }
 
-    /// Displays "Copied!" message briefly in the status bar
+    /// Displays "Copied!" message briefly in the status bar.
     private func showCopiedFeedback() {
         isShowingFeedback = true
         statusItem.button?.title = "✓ Copied"
@@ -217,14 +116,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // MARK: - Menu Setup
 
-    /// Creates and configures the options menu
-    /// - Returns: Configured NSMenu with all options
+    /// Creates and configures the options menu.
     private func setupMenu() -> NSMenu {
         let menu = NSMenu()
 
         // Display seconds toggle
         let showSecondsItem = NSMenuItem(title: "Display Seconds", action: #selector(toggleSeconds), keyEquivalent: "")
-        showSecondsItem.state = showSeconds ? .on : .off
+        showSecondsItem.state = settings.showSeconds ? .on : .off
         menu.addItem(showSecondsItem)
 
         // Date Format submenu
@@ -232,15 +130,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let dateFormatSubmenu = NSMenu()
 
         let noneItem = NSMenuItem(title: "None", action: #selector(setDateFormatNone), keyEquivalent: "")
-        noneItem.state = !showDate ? .on : .off
+        noneItem.state = !settings.showDate ? .on : .off
         dateFormatSubmenu.addItem(noneItem)
 
         let dayMonthDateItem = NSMenuItem(title: "Tue Dec 2", action: #selector(setDateFormatDayMonthDate), keyEquivalent: "")
-        dayMonthDateItem.state = (showDate && dateFormat == .dayMonthDate) ? .on : .off
+        dayMonthDateItem.state = (settings.showDate && settings.dateFormat == .dayMonthDate) ? .on : .off
         dateFormatSubmenu.addItem(dayMonthDateItem)
 
         let dayDateMonthItem = NSMenuItem(title: "Tue 2 Dec", action: #selector(setDateFormatDayDateMonth), keyEquivalent: "")
-        dayDateMonthItem.state = (showDate && dateFormat == .dayDateMonth) ? .on : .off
+        dayDateMonthItem.state = (settings.showDate && settings.dateFormat == .dayDateMonth) ? .on : .off
         dateFormatSubmenu.addItem(dayDateMonthItem)
 
         dateFormatItem.submenu = dateFormatSubmenu
@@ -251,15 +149,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let displaySuffixSubmenu = NSMenu()
 
         let zSuffixItem = NSMenuItem(title: "Z (14:23:45Z)", action: #selector(setDisplaySuffixZ), keyEquivalent: "")
-        zSuffixItem.state = displaySuffix == .z ? .on : .off
+        zSuffixItem.state = settings.displaySuffix == .z ? .on : .off
         displaySuffixSubmenu.addItem(zSuffixItem)
 
         let utcSuffixItem = NSMenuItem(title: "UTC (14:23:45 UTC)", action: #selector(setDisplaySuffixUTC), keyEquivalent: "")
-        utcSuffixItem.state = displaySuffix == .utc ? .on : .off
+        utcSuffixItem.state = settings.displaySuffix == .utc ? .on : .off
         displaySuffixSubmenu.addItem(utcSuffixItem)
 
         let noneSuffixItem = NSMenuItem(title: "None (14:23:45)", action: #selector(setDisplaySuffixNone), keyEquivalent: "")
-        noneSuffixItem.state = displaySuffix == .none ? .on : .off
+        noneSuffixItem.state = settings.displaySuffix == .none ? .on : .off
         displaySuffixSubmenu.addItem(noneSuffixItem)
 
         displaySuffixItem.submenu = displaySuffixSubmenu
@@ -269,24 +167,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let copyFormatItem = NSMenuItem(title: "Copy Format", action: nil, keyEquivalent: "")
         let copyFormatSubmenu = NSMenu()
 
-        let displayExample = UTCTimeFormatter.format(as: .humanReadable(showSeconds: showSeconds, suffix: displaySuffix))
+        let displayExample = UTCTimeFormatter.format(as: .humanReadable(showSeconds: settings.showSeconds, suffix: settings.displaySuffix))
         let displayItem = NSMenuItem(title: "Display (\(displayExample))", action: #selector(setCopyFormatDisplay), keyEquivalent: "")
-        displayItem.state = copyFormat == .display ? .on : .off
+        displayItem.state = settings.copyFormat == .display ? .on : .off
         copyFormatSubmenu.addItem(displayItem)
 
         let unixTimestampItem = NSMenuItem(title: "Unix Timestamp (1733150625)", action: #selector(setCopyFormatUnixTimestamp), keyEquivalent: "")
-        unixTimestampItem.state = copyFormat == .unixTimestamp ? .on : .off
+        unixTimestampItem.state = settings.copyFormat == .unixTimestamp ? .on : .off
         copyFormatSubmenu.addItem(unixTimestampItem)
 
         let rfc3339Item = NSMenuItem(title: "RFC 3339 (2025-12-02T14:23:45Z)", action: #selector(setCopyFormatRFC3339), keyEquivalent: "")
-        rfc3339Item.state = copyFormat == .rfc3339 ? .on : .off
+        rfc3339Item.state = settings.copyFormat == .rfc3339 ? .on : .off
         copyFormatSubmenu.addItem(rfc3339Item)
 
         copyFormatItem.submenu = copyFormatSubmenu
         menu.addItem(copyFormatItem)
 
         // Copy Shortcut
-        let shortcutTitle = copyShortcut.map { "Copy Shortcut (\($0.display))" } ?? "Copy Shortcut…"
+        let shortcutTitle = settings.copyShortcut.map { "Copy Shortcut (\($0.display))" } ?? "Copy Shortcut…"
         let copyShortcutItem = NSMenuItem(title: shortcutTitle, action: #selector(openShortcutRecorder), keyEquivalent: "")
         menu.addItem(copyShortcutItem)
 
@@ -312,53 +210,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     // MARK: - Menu Actions
 
     @objc func toggleSeconds(_ sender: NSMenuItem) {
-        showSeconds.toggle()
-        sender.state = showSeconds ? .on : .off
+        settings.showSeconds.toggle()
+        sender.state = settings.showSeconds ? .on : .off
         updateUTC()
     }
 
     @objc func setDateFormatNone() {
-        showDate = false
+        settings.showDate = false
         updateUTC()
     }
 
     @objc func setDateFormatDayMonthDate() {
-        showDate = true
-        dateFormat = .dayMonthDate
+        settings.showDate = true
+        settings.dateFormat = .dayMonthDate
         updateUTC()
     }
 
     @objc func setDateFormatDayDateMonth() {
-        showDate = true
-        dateFormat = .dayDateMonth
+        settings.showDate = true
+        settings.dateFormat = .dayDateMonth
         updateUTC()
     }
 
     @objc func setDisplaySuffixUTC() {
-        displaySuffix = .utc
+        settings.displaySuffix = .utc
         updateUTC()
     }
 
     @objc func setDisplaySuffixZ() {
-        displaySuffix = .z
+        settings.displaySuffix = .z
         updateUTC()
     }
 
     @objc func setDisplaySuffixNone() {
-        displaySuffix = .none
+        settings.displaySuffix = .none
         updateUTC()
     }
 
     @objc func setCopyFormatDisplay() {
-        copyFormat = .display
+        settings.copyFormat = .display
     }
 
     @objc func setCopyFormatUnixTimestamp() {
-        copyFormat = .unixTimestamp
+        settings.copyFormat = .unixTimestamp
     }
 
     @objc func setCopyFormatRFC3339() {
-        copyFormat = .rfc3339
+        settings.copyFormat = .rfc3339
     }
 
     #if IS_PAID_BUILD
@@ -378,15 +276,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // MARK: - Time Formatting
 
-    /// Formats the current time according to the selected copy format
-    /// - Returns: Formatted time string ready for clipboard
+    /// Formats the current time according to the selected copy format.
     func getFormattedTimeForCopy() -> String {
         let format: UTCTimeFormatter.Format
 
-        switch copyFormat {
+        switch settings.copyFormat {
         case .display:
             // Match current display settings for copy output
-            format = .humanReadable(showSeconds: showSeconds, suffix: displaySuffix)
+            format = .humanReadable(showSeconds: settings.showSeconds, suffix: settings.displaySuffix)
         case .unixTimestamp:
             format = .unixTimestamp
         case .rfc3339:
@@ -396,89 +293,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return UTCTimeFormatter.format(as: format)
     }
 
-    // MARK: - Hot Key Management
-
-    /// Installs the Carbon event handler that fires on every registered hot-key press.
-    /// Call once at launch; the handler stays alive for the app's lifetime.
-    private func installHotKeyHandler() {
-        var eventSpec = EventTypeSpec(
-            eventClass: OSType(kEventClassKeyboard),
-            eventKind: UInt32(kEventHotKeyPressed)
-        )
-        let selfPointer = Unmanaged.passUnretained(self).toOpaque()
-        InstallEventHandler(
-            GetApplicationEventTarget(),
-            { (_, _, userData) -> OSStatus in
-                guard let ptr = userData else { return OSStatus(eventNotHandledErr) }
-                let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
-                delegate.copyTimeToClipboard()
-                return noErr
-            },
-            1,
-            &eventSpec,
-            selfPointer,
-            &hotKeyHandler
-        )
-    }
-
-    /// Attempts to register the currently saved shortcut without disturbing the existing one.
-    /// The old registration is only released after the new one succeeds, so a failed
-    /// registration leaves the previous hotkey intact. Returns whether registration succeeded.
-    @discardableResult
-    func registerHotKey() -> Bool {
-        guard let shortcut = copyShortcut else {
-            unregisterHotKey()
-            return true
-        }
-
-        var carbonModifiers: UInt32 = 0
-        if shortcut.modifierFlags.contains(.command) { carbonModifiers |= UInt32(cmdKey) }
-        if shortcut.modifierFlags.contains(.shift)   { carbonModifiers |= UInt32(shiftKey) }
-        if shortcut.modifierFlags.contains(.option)  { carbonModifiers |= UInt32(optionKey) }
-        if shortcut.modifierFlags.contains(.control) { carbonModifiers |= UInt32(controlKey) }
-
-        var hotKeyID = EventHotKeyID()
-        hotKeyID.signature = 0x5A554C55  // "ZULU"
-        hotKeyID.id = 1
-
-        var newRef: EventHotKeyRef?
-        let status = RegisterEventHotKey(
-            UInt32(shortcut.keyCode),
-            carbonModifiers,
-            hotKeyID,
-            GetApplicationEventTarget(),
-            0,
-            &newRef
-        )
-
-        guard status == noErr, let newRef = newRef else {
-            print("ZuluBar: Failed to register hotkey (error \(status))")
-            return false
-        }
-
-        // New registration succeeded — safe to release the previous one
-        unregisterHotKey()
-        hotKeyRef = newRef
-        return true
-    }
-
-    private func unregisterHotKey() {
-        guard let ref = hotKeyRef else { return }
-        UnregisterEventHotKey(ref)
-        hotKeyRef = nil
-    }
+    // MARK: - Shortcut Recorder
 
     @objc private func openShortcutRecorder() {
         recorderPanel?.close()
-        recorderPanel = HotKeyRecorderPanel(current: copyShortcut)
+        recorderPanel = HotKeyRecorderPanel(current: settings.copyShortcut)
         recorderPanel?.onShortcutChanged = { [weak self] shortcut in
             guard let self = self else { return }
-            let previous = self.copyShortcut
-            self.copyShortcut = shortcut
-            if !self.registerHotKey() {
-                // Registration failed — roll back to the previous binding
-                self.copyShortcut = previous
-                self.registerHotKey()
+            if self.hotKeyManager.activate(shortcut) {
+                // Persist only after Carbon registration succeeds, so UserDefaults
+                // and the live binding can never drift out of sync.
+                self.settings.copyShortcut = shortcut
+            } else {
                 self.recorderPanel?.registrationFailed()
             }
         }
@@ -489,8 +315,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // MARK: - Timer Management
 
-    /// Starts the timer that updates the status bar display
-    /// Syncs to the next whole second for precise timing
+    /// Starts the timer that updates the status bar display, synced to the next whole second.
     func startTimer() {
         // Calculate time until next whole second for precise sync
         let now = Date()
@@ -512,14 +337,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         RunLoop.main.add(syncTimer, forMode: .common)
     }
 
-    /// Updates the status bar with the current UTC time
+    /// Updates the status bar with the current UTC time.
     func updateUTC() {
-        // Don't update if showing feedback
         guard !isShowingFeedback else { return }
 
         let display = StatusBarDisplay(
-            dateFormat: showDate ? dateFormat : nil,
-            timeFormat: .humanReadable(showSeconds: showSeconds, suffix: displaySuffix)
+            dateFormat: settings.showDate ? settings.dateFormat : nil,
+            timeFormat: .humanReadable(showSeconds: settings.showSeconds, suffix: settings.displaySuffix)
         )
         statusItem.button?.title = StatusBarRenderer.render(display)
     }

--- a/ZuluBar/HotKey.swift
+++ b/ZuluBar/HotKey.swift
@@ -1,0 +1,77 @@
+import Carbon
+import Cocoa
+
+/// A resolved keyboard shortcut binding (key code + modifiers).
+/// `display` and `carbonModifiers` are computed from the stored fields, so
+/// persistence only needs to serialize `keyCode` and `modifierFlags`.
+struct HotKey: Equatable {
+    let keyCode: UInt16
+    let modifierFlags: NSEvent.ModifierFlags
+
+    /// Human-readable display string, e.g. "⌘⇧C".
+    var display: String {
+        var result = ""
+        if modifierFlags.contains(.control) { result += "⌃" }
+        if modifierFlags.contains(.option)  { result += "⌥" }
+        if modifierFlags.contains(.shift)   { result += "⇧" }
+        if modifierFlags.contains(.command) { result += "⌘" }
+        result += Self.keyName(for: keyCode)
+        return result
+    }
+
+    /// Carbon modifier flags corresponding to `modifierFlags`.
+    var carbonModifiers: UInt32 {
+        var result: UInt32 = 0
+        if modifierFlags.contains(.command) { result |= UInt32(cmdKey) }
+        if modifierFlags.contains(.shift)   { result |= UInt32(shiftKey) }
+        if modifierFlags.contains(.option)  { result |= UInt32(optionKey) }
+        if modifierFlags.contains(.control) { result |= UInt32(controlKey) }
+        return result
+    }
+
+    // MARK: - Key name translation
+
+    private static let namedKeys: [UInt16: String] = [
+        36: "↩", 48: "⇥", 49: "Space", 51: "⌫", 53: "⎋",
+        96: "F5", 97: "F6", 98: "F7", 99: "F3", 100: "F8",
+        101: "F9", 103: "F11", 105: "F13", 107: "F14", 109: "F10",
+        111: "F12", 113: "F15", 115: "↖", 116: "⇞", 117: "⌦",
+        118: "F4", 119: "↘", 120: "F2", 121: "⇟", 122: "F1",
+        123: "←", 124: "→", 125: "↓", 126: "↑",
+    ]
+
+    private static func keyName(for keyCode: UInt16) -> String {
+        if let name = namedKeys[keyCode] { return name }
+        return characterName(for: keyCode) ?? "(\(keyCode))"
+    }
+
+    /// Translates a virtual key code to its unmodified character using the current keyboard layout.
+    private static func characterName(for keyCode: UInt16) -> String? {
+        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else { return nil }
+        guard let layoutDataRef = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else { return nil }
+        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue() as Data
+
+        return layoutData.withUnsafeBytes { rawBuffer -> String? in
+            guard let layoutPtr = rawBuffer.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else { return nil }
+            var deadKeyState: UInt32 = 0
+            var unicodeChars = [UniChar](repeating: 0, count: 4)
+            var charCount = 0
+            let status = UCKeyTranslate(
+                layoutPtr,
+                keyCode,
+                UInt16(kUCKeyActionDisplay),
+                0,
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                4,
+                &charCount,
+                &unicodeChars
+            )
+            guard status == noErr, charCount > 0 else { return nil }
+            let scalars = unicodeChars[0..<charCount].compactMap { Unicode.Scalar(UInt32($0)) }
+            let string = String(String.UnicodeScalarView(scalars)).uppercased()
+            return string.isEmpty ? nil : string
+        }
+    }
+}

--- a/ZuluBar/HotKeyManager.swift
+++ b/ZuluBar/HotKeyManager.swift
@@ -1,0 +1,88 @@
+import Carbon
+import Cocoa
+
+/// Owns the Carbon global hot-key registration for the app.
+///
+/// The API is deliberately shaped so UserDefaults and Carbon cannot drift
+/// apart: `activate(_:)` returns `false` if registration fails, and the
+/// caller is expected to persist the hotkey only after a successful return.
+/// On failure, the previous binding is left intact.
+final class HotKeyManager {
+
+    /// Called on the main thread whenever the registered hot key fires.
+    var onTrigger: (() -> Void)?
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var handlerRef: EventHandlerRef?
+
+    init() {
+        installHandler()
+    }
+
+    deinit {
+        if let ref = hotKeyRef { UnregisterEventHotKey(ref) }
+        if let handler = handlerRef { RemoveEventHandler(handler) }
+    }
+
+    /// Attempts to register `hotKey` as the global shortcut. Passing `nil`
+    /// clears any current binding.
+    /// - Returns: `true` on success (or when passed `nil`). On `false`, the
+    ///   previous binding remains active.
+    @discardableResult
+    func activate(_ hotKey: HotKey?) -> Bool {
+        guard let hotKey = hotKey else {
+            unregister()
+            return true
+        }
+
+        var id = EventHotKeyID()
+        id.signature = 0x5A554C55  // "ZULU"
+        id.id = 1
+
+        var newRef: EventHotKeyRef?
+        let status = RegisterEventHotKey(
+            UInt32(hotKey.keyCode),
+            hotKey.carbonModifiers,
+            id,
+            GetApplicationEventTarget(),
+            0,
+            &newRef
+        )
+
+        guard status == noErr, let newRef = newRef else {
+            return false
+        }
+
+        // New registration succeeded — safe to release the previous one.
+        unregister()
+        hotKeyRef = newRef
+        return true
+    }
+
+    private func unregister() {
+        guard let ref = hotKeyRef else { return }
+        UnregisterEventHotKey(ref)
+        hotKeyRef = nil
+    }
+
+    private func installHandler() {
+        var eventSpec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        let selfPointer = Unmanaged.passUnretained(self).toOpaque()
+        InstallEventHandler(
+            GetApplicationEventTarget(),
+            { (_, _, userData) -> OSStatus in
+                guard let ptr = userData else { return OSStatus(eventNotHandledErr) }
+                let manager = Unmanaged<HotKeyManager>.fromOpaque(ptr).takeUnretainedValue()
+                manager.onTrigger?()
+                return noErr
+            },
+            1,
+            &eventSpec,
+            selfPointer,
+            &handlerRef
+        )
+    }
+}

--- a/ZuluBar/HotKeyRecorderPanel.swift
+++ b/ZuluBar/HotKeyRecorderPanel.swift
@@ -5,7 +5,7 @@ import Carbon
 ///
 /// Usage:
 /// ```swift
-/// let panel = HotKeyRecorderPanel(current: copyShortcut)
+/// let panel = HotKeyRecorderPanel(current: settings.copyShortcut)
 /// panel.onShortcutChanged = { [weak self] shortcut in ... }
 /// panel.makeKeyAndOrderFront(nil)
 /// ```
@@ -14,7 +14,7 @@ class HotKeyRecorderPanel: NSPanel {
     // MARK: - Public
 
     /// Called immediately when the user records a new shortcut or clears the existing one.
-    var onShortcutChanged: ((AppDelegate.HotKey?) -> Void)?
+    var onShortcutChanged: ((HotKey?) -> Void)?
 
     // MARK: - Private
 
@@ -24,14 +24,14 @@ class HotKeyRecorderPanel: NSPanel {
     private let clearButton = NSButton()
     private let doneButton = NSButton()
 
-    private var currentShortcut: AppDelegate.HotKey?
-    private var shortcutBeforeAttempt: AppDelegate.HotKey?
+    private var currentShortcut: HotKey?
+    private var shortcutBeforeAttempt: HotKey?
     private var isRecording = false
     private var localEventMonitor: Any?
 
     // MARK: - Init
 
-    init(current: AppDelegate.HotKey?) {
+    init(current: HotKey?) {
         self.currentShortcut = current
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: 300, height: 150),
@@ -181,8 +181,7 @@ class HotKeyRecorderPanel: NSPanel {
             return
         }
 
-        let display = buildDisplayString(keyCode: event.keyCode, modifiers: modifiers)
-        let shortcut = AppDelegate.HotKey(keyCode: event.keyCode, modifierFlags: modifiers, display: display)
+        let shortcut = HotKey(keyCode: event.keyCode, modifierFlags: modifiers)
 
         stopRecording(restoreDisplay: false)
         shortcutBeforeAttempt = currentShortcut
@@ -223,61 +222,5 @@ class HotKeyRecorderPanel: NSPanel {
     override func close() {
         stopRecording(restoreDisplay: false)
         super.close()
-    }
-
-    // MARK: - Key Name Helpers
-
-    private func buildDisplayString(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> String {
-        var result = ""
-        if modifiers.contains(.control) { result += "⌃" }
-        if modifiers.contains(.option)  { result += "⌥" }
-        if modifiers.contains(.shift)   { result += "⇧" }
-        if modifiers.contains(.command) { result += "⌘" }
-        result += keyName(for: keyCode)
-        return result
-    }
-
-    private func keyName(for keyCode: UInt16) -> String {
-        // Named keys that UCKeyTranslate doesn't produce useful strings for
-        let namedKeys: [UInt16: String] = [
-            36: "↩", 48: "⇥", 49: "Space", 51: "⌫", 53: "⎋",
-            96: "F5", 97: "F6", 98: "F7", 99: "F3", 100: "F8",
-            101: "F9", 103: "F11", 105: "F13", 107: "F14", 109: "F10",
-            111: "F12", 113: "F15", 115: "↖", 116: "⇞", 117: "⌦",
-            118: "F4", 119: "↘", 120: "F2", 121: "⇟", 122: "F1",
-            123: "←", 124: "→", 125: "↓", 126: "↑",
-        ]
-        if let name = namedKeys[keyCode] { return name }
-        return characterName(for: keyCode) ?? "(\(keyCode))"
-    }
-
-    /// Translates a virtual key code to its unmodified character using the current keyboard layout.
-    private func characterName(for keyCode: UInt16) -> String? {
-        guard let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else { return nil }
-        guard let layoutDataRef = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) else { return nil }
-        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataRef).takeUnretainedValue() as Data
-
-        return layoutData.withUnsafeBytes { rawBuffer -> String? in
-            guard let layoutPtr = rawBuffer.baseAddress?.assumingMemoryBound(to: UCKeyboardLayout.self) else { return nil }
-            var deadKeyState: UInt32 = 0
-            var unicodeChars = [UniChar](repeating: 0, count: 4)
-            var charCount = 0
-            let status = UCKeyTranslate(
-                layoutPtr,
-                keyCode,
-                UInt16(kUCKeyActionDisplay),
-                0,
-                UInt32(LMGetKbdType()),
-                OptionBits(kUCKeyTranslateNoDeadKeysBit),
-                &deadKeyState,
-                4,
-                &charCount,
-                &unicodeChars
-            )
-            guard status == noErr, charCount > 0 else { return nil }
-            let scalars = unicodeChars[0..<charCount].compactMap { Unicode.Scalar(UInt32($0)) }
-            let string = String(String.UnicodeScalarView(scalars)).uppercased()
-            return string.isEmpty ? nil : string
-        }
     }
 }

--- a/ZuluBar/Settings.swift
+++ b/ZuluBar/Settings.swift
@@ -1,0 +1,89 @@
+import Cocoa
+
+/// Available formats for copying time to clipboard.
+enum CopyFormat: String, CaseIterable {
+    case display = "Display"
+    case unixTimestamp = "Unix Timestamp"
+    case rfc3339 = "RFC 3339"
+}
+
+/// UserDefaults-backed user preferences.
+/// The `defaults` parameter is injectable so tests can use a scoped suite
+/// instead of polluting `UserDefaults.standard`.
+struct Settings {
+    let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    private enum Keys {
+        static let showSeconds = "showSeconds"
+        static let showDate = "showDate"
+        static let dateFormat = "dateFormat"
+        static let displaySuffix = "displaySuffix"
+        static let copyFormat = "copyFormat"
+        static let copyShortcutKeyCode = "copyShortcutKeyCode"
+        static let copyShortcutModifiers = "copyShortcutModifiers"
+        static let copyShortcutDisplay = "copyShortcutDisplay"  // legacy (pre-PR#2); no longer written
+    }
+
+    var showSeconds: Bool {
+        get { defaults.object(forKey: Keys.showSeconds) as? Bool ?? true }
+        set { defaults.set(newValue, forKey: Keys.showSeconds) }
+    }
+
+    var showDate: Bool {
+        get { defaults.object(forKey: Keys.showDate) as? Bool ?? false }
+        set { defaults.set(newValue, forKey: Keys.showDate) }
+    }
+
+    var dateFormat: DateFormat {
+        get {
+            guard let raw = defaults.string(forKey: Keys.dateFormat),
+                  let format = DateFormat(rawValue: raw) else { return .dayMonthDate }
+            return format
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.dateFormat) }
+    }
+
+    var displaySuffix: UTCTimeFormatter.Suffix {
+        get {
+            guard let raw = defaults.string(forKey: Keys.displaySuffix),
+                  let suffix = UTCTimeFormatter.Suffix(rawValue: raw) else { return .z }
+            return suffix
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.displaySuffix) }
+    }
+
+    var copyFormat: CopyFormat {
+        get {
+            if let raw = defaults.string(forKey: Keys.copyFormat) {
+                if raw == "Human Readable" { return .display }  // legacy value (pre-0.2.0)
+                if let format = CopyFormat(rawValue: raw) { return format }
+            }
+            return .display
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.copyFormat) }
+    }
+
+    var copyShortcut: HotKey? {
+        get {
+            guard let keyCodeInt = defaults.object(forKey: Keys.copyShortcutKeyCode) as? Int else { return nil }
+            let keyCode = UInt16(clamping: keyCodeInt)
+            let raw = UInt(bitPattern: defaults.integer(forKey: Keys.copyShortcutModifiers))
+            return HotKey(keyCode: keyCode, modifierFlags: NSEvent.ModifierFlags(rawValue: raw))
+        }
+        set {
+            if let shortcut = newValue {
+                defaults.set(Int(shortcut.keyCode), forKey: Keys.copyShortcutKeyCode)
+                defaults.set(Int(bitPattern: UInt(shortcut.modifierFlags.rawValue)), forKey: Keys.copyShortcutModifiers)
+                defaults.removeObject(forKey: Keys.copyShortcutDisplay)  // drop legacy value on any write
+            } else {
+                defaults.removeObject(forKey: Keys.copyShortcutKeyCode)
+                defaults.removeObject(forKey: Keys.copyShortcutModifiers)
+                defaults.removeObject(forKey: Keys.copyShortcutDisplay)
+            }
+        }
+    }
+}

--- a/ZuluBar/ZuluBarApp.swift
+++ b/ZuluBar/ZuluBarApp.swift
@@ -5,6 +5,6 @@ struct ZuluBarApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
     var body: some Scene {
-        Settings {} // keeps SwiftUI lifecycle happy, no windows
+        SwiftUI.Settings {} // keeps SwiftUI lifecycle happy, no windows
     }
 }

--- a/ZuluBarTests/AppDelegateTests.swift
+++ b/ZuluBarTests/AppDelegateTests.swift
@@ -25,81 +25,82 @@ final class AppDelegateTests: XCTestCase {
     // MARK: - Default Values
 
     func testShowSecondsDefaultIsTrue() {
-        XCTAssertTrue(delegate.showSeconds)
+        XCTAssertTrue(delegate.settings.showSeconds)
     }
 
     func testShowDateDefaultIsFalse() {
-        XCTAssertFalse(delegate.showDate)
+        XCTAssertFalse(delegate.settings.showDate)
     }
 
-    func testDisplaySuffixDefaultIsUTC() {
-        XCTAssertEqual(delegate.displaySuffix, .z)
+    func testDisplaySuffixDefaultIsZ() {
+        XCTAssertEqual(delegate.settings.displaySuffix, .z)
     }
 
     func testCopyFormatDefaultIsDisplay() {
-        XCTAssertEqual(delegate.copyFormat, .display)
+        XCTAssertEqual(delegate.settings.copyFormat, .display)
     }
 
     func testDateFormatDefaultIsDayMonthDate() {
-        XCTAssertEqual(delegate.dateFormat, .dayMonthDate)
+        XCTAssertEqual(delegate.settings.dateFormat, .dayMonthDate)
     }
 
     // MARK: - Settings Persistence
 
     func testShowSecondsPersists() {
-        delegate.showSeconds = false
-        XCTAssertFalse(delegate.showSeconds)
+        delegate.settings.showSeconds = false
+        XCTAssertFalse(delegate.settings.showSeconds)
         XCTAssertFalse(defaults.bool(forKey: "showSeconds"))
     }
 
     func testShowDatePersists() {
-        delegate.showDate = true
-        XCTAssertTrue(delegate.showDate)
+        delegate.settings.showDate = true
+        XCTAssertTrue(delegate.settings.showDate)
         XCTAssertTrue(defaults.bool(forKey: "showDate"))
     }
 
     func testDisplaySuffixPersists() {
-        delegate.displaySuffix = .z
-        XCTAssertEqual(delegate.displaySuffix, .z)
+        delegate.settings.displaySuffix = .z
+        XCTAssertEqual(delegate.settings.displaySuffix, .z)
         XCTAssertEqual(defaults.string(forKey: "displaySuffix"), "Z")
     }
 
     func testCopyFormatPersists() {
-        delegate.copyFormat = .rfc3339
-        XCTAssertEqual(delegate.copyFormat, .rfc3339)
+        delegate.settings.copyFormat = .rfc3339
+        XCTAssertEqual(delegate.settings.copyFormat, .rfc3339)
         XCTAssertEqual(defaults.string(forKey: "copyFormat"), "RFC 3339")
     }
 
     func testDateFormatPersists() {
-        delegate.dateFormat = .dayDateMonth
-        XCTAssertEqual(delegate.dateFormat, .dayDateMonth)
+        delegate.settings.dateFormat = .dayDateMonth
+        XCTAssertEqual(delegate.settings.dateFormat, .dayDateMonth)
         XCTAssertEqual(defaults.string(forKey: "dateFormat"), "Tue 2 Dec")
     }
 
     // MARK: - Copy Shortcut
 
     func testCopyShortcutDefaultIsNil() {
-        XCTAssertNil(delegate.copyShortcut)
+        XCTAssertNil(delegate.settings.copyShortcut)
     }
 
     func testCopyShortcutPersists() {
-        let shortcut = AppDelegate.HotKey(
-            keyCode: 8,
-            modifierFlags: [.command],
-            display: "⌘C"
-        )
-        delegate.copyShortcut = shortcut
-        XCTAssertEqual(delegate.copyShortcut?.keyCode, 8)
-        XCTAssertEqual(delegate.copyShortcut?.display, "⌘C")
-        XCTAssertTrue(delegate.copyShortcut?.modifierFlags.contains(.command) == true)
+        let shortcut = HotKey(keyCode: 8, modifierFlags: [.command])
+        delegate.settings.copyShortcut = shortcut
+        XCTAssertEqual(delegate.settings.copyShortcut?.keyCode, 8)
+        XCTAssertTrue(delegate.settings.copyShortcut?.modifierFlags.contains(.command) == true)
         XCTAssertEqual(defaults.integer(forKey: "copyShortcutKeyCode"), 8)
-        XCTAssertEqual(defaults.string(forKey: "copyShortcutDisplay"), "⌘C")
+    }
+
+    func testCopyShortcutDisplayIsComputed() {
+        // keyCode 8 is "C" on a US keyboard; combined with ⌘ the display should start with ⌘.
+        let shortcut = HotKey(keyCode: 8, modifierFlags: [.command])
+        delegate.settings.copyShortcut = shortcut
+        XCTAssertTrue(delegate.settings.copyShortcut?.display.hasPrefix("⌘") == true)
     }
 
     func testCopyShortcutClearRemovesAllKeys() {
-        delegate.copyShortcut = AppDelegate.HotKey(keyCode: 8, modifierFlags: [.command], display: "⌘C")
-        delegate.copyShortcut = nil
-        XCTAssertNil(delegate.copyShortcut)
+        delegate.settings.copyShortcut = HotKey(keyCode: 8, modifierFlags: [.command])
+        delegate.settings.copyShortcut = nil
+        XCTAssertNil(delegate.settings.copyShortcut)
         XCTAssertNil(defaults.object(forKey: "copyShortcutKeyCode"))
         XCTAssertNil(defaults.object(forKey: "copyShortcutModifiers"))
         XCTAssertNil(defaults.object(forKey: "copyShortcutDisplay"))
@@ -107,8 +108,8 @@ final class AppDelegateTests: XCTestCase {
 
     func testCopyShortcutModifierRoundTrip() {
         let flags: NSEvent.ModifierFlags = [.command, .shift]
-        delegate.copyShortcut = AppDelegate.HotKey(keyCode: 3, modifierFlags: flags, display: "⌘⇧F")
-        let recovered = delegate.copyShortcut
+        delegate.settings.copyShortcut = HotKey(keyCode: 3, modifierFlags: flags)
+        let recovered = delegate.settings.copyShortcut
         XCTAssertNotNil(recovered)
         XCTAssertTrue(recovered?.modifierFlags.contains(.command) == true)
         XCTAssertTrue(recovered?.modifierFlags.contains(.shift) == true)
@@ -119,14 +120,14 @@ final class AppDelegateTests: XCTestCase {
     // MARK: - Copy Format Output
 
     func testCopyDisplayMatchesSuffix() {
-        delegate.copyFormat = .display
+        delegate.settings.copyFormat = .display
         let result = delegate.getFormattedTimeForCopy()
         XCTAssertTrue(result.hasSuffix("Z"), "Expected Z suffix, got: \(result)")
         XCTAssertTrue(result.contains(":"), "Expected time with colons, got: \(result)")
     }
 
     func testCopyUnixTimestampIsInteger() {
-        delegate.copyFormat = .unixTimestamp
+        delegate.settings.copyFormat = .unixTimestamp
         let result = delegate.getFormattedTimeForCopy()
         let timestamp = Int(result)
         XCTAssertNotNil(timestamp, "Expected integer, got: \(result)")
@@ -134,7 +135,7 @@ final class AppDelegateTests: XCTestCase {
     }
 
     func testCopyRFC3339Format() {
-        delegate.copyFormat = .rfc3339
+        delegate.settings.copyFormat = .rfc3339
         let result = delegate.getFormattedTimeForCopy()
         let regex = try! NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"#)
         let match = regex.firstMatch(in: result, range: NSRange(result.startIndex..., in: result))


### PR DESCRIPTION
Stacked on top of #14. Merge #14 first, then re-target this to \`main\` (or rebase).

## Summary

Splits AppDelegate along responsibility seams. **571 → 350 lines.**

**`HotKey.swift`** — top-level value type (was `AppDelegate.HotKey`). Absorbs two pieces of behavior that used to live in other files as data-shaped-like-code: \`buildDisplayString\` from \`HotKeyRecorderPanel\`, and the Carbon modifier arithmetic from `registerHotKey()`. Both now computed properties:

```swift
struct HotKey: Equatable {
    let keyCode: UInt16
    let modifierFlags: NSEvent.ModifierFlags
    var display: String { /* "⌘⇧C" */ }
    var carbonModifiers: UInt32 { /* cmdKey | shiftKey | ... */ }
}
```

As a side effect, persistence no longer stores the display string — it's derived from \`keyCode + modifierFlags\`.

**`Settings.swift`** — all UserDefaults-backed accessors. Takes an injectable \`defaults: UserDefaults\` parameter so follow-up test hermeticity (PR 3) can swap in a scoped suite. \`CopyFormat\` moves here since it's a user-preference type.

**`HotKeyManager.swift`** — owns Carbon global hot-key registration. The API is shaped so UserDefaults and Carbon cannot drift apart:

```swift
@discardableResult
func activate(_ hotKey: HotKey?) -> Bool
```

Returns \`false\` on registration failure, leaving the previous binding intact. The caller (\`openShortcutRecorder\`) now persists only **after** \`activate()\` returns true. This deletes the rollback dance that existed because the old \`registerHotKey()\` read its input from UserDefaults instead of taking a parameter.

## Incidental changes

- SwiftUI's \`Settings\` scene is now qualified as \`SwiftUI.Settings\` in \`ZuluBarApp.swift\` — name collision with the new type.
- \`HotKeyRecorderPanel\` drops its local \`keyName\`/\`characterName\`/\`buildDisplayString\` helpers (now on \`HotKey\`).
- Legacy UserDefaults key \`copyShortcutDisplay\` is removed on any write but tolerated on read — no migration needed since presence of \`copyShortcutKeyCode\` now gates shortcut existence.

## Test plan

- [x] `make build-free` succeeds
- [x] \`make test\` — all 26 tests pass (added one for computed \`display\`)
- [x] Manual: record a new shortcut, verify it activates; trigger it, verify copy works
- [x] Manual: clear the shortcut, verify no binding remains
- [x] Manual: upgrade path — install with existing \`copyShortcutDisplay\` in UserDefaults, launch new build, confirm shortcut still works