### PR TITLE
test: hermetic UserDefaults suite for AppDelegate tests

### DIFF
--- a/ZuluBarTests/AppDelegateTests.swift
+++ b/ZuluBarTests/AppDelegateTests.swift
@@ -149,11 +149,13 @@ final class AppDelegateTests: XCTestCase {
 
     func testSettingsWriteDoesNotTouchStandardDefaults() {
         // Sanity: make sure a flipped setting in this test doesn't leak
-        // into UserDefaults.standard.
+        // into UserDefaults.standard. Write the negation of whatever
+        // standard currently holds so that an accidental passthrough
+        // write is guaranteed to flip the observed value.
         let standard = UserDefaults.standard
-        let prior = standard.object(forKey: "showSeconds")
-        delegate.settings.showSeconds = false
-        XCTAssertEqual(standard.object(forKey: "showSeconds") as? Bool, prior as? Bool,
+        let prior = (standard.object(forKey: "showSeconds") as? Bool) ?? true
+        delegate.settings.showSeconds = !prior
+        XCTAssertEqual(standard.object(forKey: "showSeconds") as? Bool ?? true, prior,
                        "Test write should not have mutated UserDefaults.standard")
     }
 }

--- a/ZuluBarTests/AppDelegateTests.swift
+++ b/ZuluBarTests/AppDelegateTests.swift
@@ -4,21 +4,24 @@ import XCTest
 final class AppDelegateTests: XCTestCase {
 
     private var delegate: AppDelegate!
-    private let defaults = UserDefaults.standard
-    private let testKeys = [
-        "showSeconds", "showDate", "dateFormat", "displaySuffix", "copyFormat",
-        "copyShortcutKeyCode", "copyShortcutModifiers", "copyShortcutDisplay",
-    ]
+    private var suiteName: String!
+    private var testDefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
-        testKeys.forEach { defaults.removeObject(forKey: $0) }
+        // Scoped UserDefaults suite so tests don't pollute — or get polluted by —
+        // the real app's settings in UserDefaults.standard.
+        suiteName = "com.zulubar.tests.\(UUID().uuidString)"
+        testDefaults = UserDefaults(suiteName: suiteName)
         delegate = AppDelegate()
+        delegate.settings = Settings(defaults: testDefaults)
     }
 
     override func tearDown() {
-        testKeys.forEach { defaults.removeObject(forKey: $0) }
+        testDefaults.removePersistentDomain(forName: suiteName)
         delegate = nil
+        testDefaults = nil
+        suiteName = nil
         super.tearDown()
     }
 
@@ -49,31 +52,31 @@ final class AppDelegateTests: XCTestCase {
     func testShowSecondsPersists() {
         delegate.settings.showSeconds = false
         XCTAssertFalse(delegate.settings.showSeconds)
-        XCTAssertFalse(defaults.bool(forKey: "showSeconds"))
+        XCTAssertFalse(testDefaults.bool(forKey: "showSeconds"))
     }
 
     func testShowDatePersists() {
         delegate.settings.showDate = true
         XCTAssertTrue(delegate.settings.showDate)
-        XCTAssertTrue(defaults.bool(forKey: "showDate"))
+        XCTAssertTrue(testDefaults.bool(forKey: "showDate"))
     }
 
     func testDisplaySuffixPersists() {
         delegate.settings.displaySuffix = .z
         XCTAssertEqual(delegate.settings.displaySuffix, .z)
-        XCTAssertEqual(defaults.string(forKey: "displaySuffix"), "Z")
+        XCTAssertEqual(testDefaults.string(forKey: "displaySuffix"), "Z")
     }
 
     func testCopyFormatPersists() {
         delegate.settings.copyFormat = .rfc3339
         XCTAssertEqual(delegate.settings.copyFormat, .rfc3339)
-        XCTAssertEqual(defaults.string(forKey: "copyFormat"), "RFC 3339")
+        XCTAssertEqual(testDefaults.string(forKey: "copyFormat"), "RFC 3339")
     }
 
     func testDateFormatPersists() {
         delegate.settings.dateFormat = .dayDateMonth
         XCTAssertEqual(delegate.settings.dateFormat, .dayDateMonth)
-        XCTAssertEqual(defaults.string(forKey: "dateFormat"), "Tue 2 Dec")
+        XCTAssertEqual(testDefaults.string(forKey: "dateFormat"), "Tue 2 Dec")
     }
 
     // MARK: - Copy Shortcut
@@ -87,7 +90,7 @@ final class AppDelegateTests: XCTestCase {
         delegate.settings.copyShortcut = shortcut
         XCTAssertEqual(delegate.settings.copyShortcut?.keyCode, 8)
         XCTAssertTrue(delegate.settings.copyShortcut?.modifierFlags.contains(.command) == true)
-        XCTAssertEqual(defaults.integer(forKey: "copyShortcutKeyCode"), 8)
+        XCTAssertEqual(testDefaults.integer(forKey: "copyShortcutKeyCode"), 8)
     }
 
     func testCopyShortcutDisplayIsComputed() {
@@ -101,9 +104,9 @@ final class AppDelegateTests: XCTestCase {
         delegate.settings.copyShortcut = HotKey(keyCode: 8, modifierFlags: [.command])
         delegate.settings.copyShortcut = nil
         XCTAssertNil(delegate.settings.copyShortcut)
-        XCTAssertNil(defaults.object(forKey: "copyShortcutKeyCode"))
-        XCTAssertNil(defaults.object(forKey: "copyShortcutModifiers"))
-        XCTAssertNil(defaults.object(forKey: "copyShortcutDisplay"))
+        XCTAssertNil(testDefaults.object(forKey: "copyShortcutKeyCode"))
+        XCTAssertNil(testDefaults.object(forKey: "copyShortcutModifiers"))
+        XCTAssertNil(testDefaults.object(forKey: "copyShortcutDisplay"))
     }
 
     func testCopyShortcutModifierRoundTrip() {
@@ -140,5 +143,17 @@ final class AppDelegateTests: XCTestCase {
         let regex = try! NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"#)
         let match = regex.firstMatch(in: result, range: NSRange(result.startIndex..., in: result))
         XCTAssertNotNil(match, "Expected RFC 3339 format, got: \(result)")
+    }
+
+    // MARK: - Test Hermeticity
+
+    func testSettingsWriteDoesNotTouchStandardDefaults() {
+        // Sanity: make sure a flipped setting in this test doesn't leak
+        // into UserDefaults.standard.
+        let standard = UserDefaults.standard
+        let prior = standard.object(forKey: "showSeconds")
+        delegate.settings.showSeconds = false
+        XCTAssertEqual(standard.object(forKey: "showSeconds") as? Bool, prior as? Bool,
+                       "Test write should not have mutated UserDefaults.standard")
     }
 }


### PR DESCRIPTION
Stacked on top of #15. Merge both predecessors first, then re-target this to \`main\` (or rebase).

## Summary

Tests previously mutated \`UserDefaults.standard\` directly, which meant running \`make test\` while the app was open would clobber the user's real settings (and vice versa). Each test case now creates a UUID-scoped \`UserDefaults(suiteName:)\`, points AppDelegate at it via the injectable \`defaults\` parameter that Settings gained in #15, and removes the suite in \`tearDown\`.

Added one guard test (\`testSettingsWriteDoesNotTouchStandardDefaults\`) so the hermeticity contract regresses loudly if someone reintroduces a reference to \`UserDefaults.standard\`.

## Why no `@Stored` property wrapper?

The original refactor plan called for a \`@Stored\` property wrapper to replace Settings' manual UserDefaults get/set boilerplate. After PR #15 landed, I re-evaluated:

- A property wrapper with **injectable storage** (required for hermetic tests) needs the \`_enclosingInstance:wrapped:storage:\` subscript pattern, which requires Settings to become a \`class\`. ~30 lines of wrapper machinery to save ~20 lines of accessors.
- A property wrapper **tied to \`UserDefaults.standard\`** is simpler but conflicts with the injectable \`defaults\` parameter — you'd lose the hermeticity win this PR delivers.

Settings after #15 is 89 lines of focused accessors. The wrapper doesn't earn its keep for a project this size. Leaving the door open: if Settings grows another dozen entries, the tradeoff flips.

## Test plan

- [x] \`make test\` — 27 tests pass (18 AppDelegate, 8 TimeFormatter, + 1 new hermeticity guard)
- [x] Run tests twice in a row, confirm no state leaks between runs
- [x] Manual: verify the app's real settings in \`~/Library/Preferences\` are untouched after running tests